### PR TITLE
Downfall 3.0 Compatibility Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@
 .classpath
 pom.xml
 pom.xml
+.idea/.name
+.idea/compiler.xml
+.idea/encodings.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml
+pom.xml
+pom.xml

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/curses/UnknownCurse.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/curses/UnknownCurse.java
@@ -1,5 +1,6 @@
 package com.megacrit.cardcrawl.mod.replay.cards.replayxover.curses;
 
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.AbstractCard.CardColor;
 import com.megacrit.cardcrawl.cards.AbstractCard.CardRarity;
@@ -27,91 +28,21 @@ public class UnknownCurse extends AbstractUnknownCard {
         this.color = CardColor.CURSE;
     }
 
+    public static ArrayList<String> unknownCurseReplacements = new ArrayList();
+
     @Override
     public Predicate<AbstractCard> myNeeds() {
-        return c -> c.color == CardColor.CURSE;
-    }
-    
-    @Override
-    public void upgrade() {}
-    
-    @Override
-    public boolean canUpgrade() {
-    	return false;
-    }
-    
-    @Override
-    public void replaceUnknown(Predicate<AbstractCard> funkyPredicate) {
-        AbstractPlayer p = AbstractDungeon.player;
-        boolean validCard;
-
-        ArrayList<String> tmp = new ArrayList<>();
-        for (AbstractCard c : CardLibrary.getAllCards()) {
-            if (!c.isSeen)
-                UnlockTracker.markCardAsSeen(c.cardID);
-            AbstractCard q = c.makeCopy();
-            validCard = !c.hasTag(CardTags.STARTER_STRIKE) && !c.hasTag(CardTags.STARTER_DEFEND) && c.type != CardType.STATUS && c.rarity != CardRarity.SPECIAL && c.color != AbstractDungeon.player.getCardColor() && !c.hasTag(SneckoMod.BANNEDFORSNECKO);
-            if (this.upgraded) {
-                if (!c.canUpgrade()) validCard = false;
-                if (validCard) q.upgrade();
-            }
-            if (funkyPredicate.test(q)) {
-                if (validCard) tmp.add(c.cardID);
-            }
-        }
-
-        AbstractCard cUnknown;
-        if (tmp.size() > 0) {
-            cUnknown = CardLibrary.cards.get(tmp.get(AbstractDungeon.cardRng.random(0, tmp.size() - 1))).makeStatEquivalentCopy();
-        } else {
-            cUnknown = new com.megacrit.cardcrawl.cards.colorless.Madness();
-        }
-
-        if (this.upgraded) cUnknown.upgrade();
-        if (cUnknown != null) {
-            p.hand.removeCard(this);
-            p.drawPile.removeCard(this);
-            if (cUnknown.cardsToPreview == null)
-                cUnknown.cardsToPreview = this.makeStatEquivalentCopy();
-            AbstractDungeon.player.drawPile.addToRandomSpot(cUnknown);
-        }
+        return c -> c.type == CardType.CURSE;
     }
 
     @Override
-    public void replaceUnknownFromHand(Predicate<AbstractCard> funkyPredicate) {
-        AbstractPlayer p = AbstractDungeon.player;
-        boolean validCard;
+    public ArrayList<String> myList() {
+        return unknownCurseReplacements;
+    }
 
-        ArrayList<String> tmp = new ArrayList<>();
-        for (AbstractCard c : CardLibrary.getAllCards()) {
-            if (!c.isSeen)
-                UnlockTracker.markCardAsSeen(c.cardID);
-            AbstractCard q = c.makeCopy();
-            validCard = !c.hasTag(SneckoMod.BANNEDFORSNECKO) && !c.hasTag(CardTags.HEALING) && !c.hasTag(CardTags.STARTER_STRIKE) && !c.hasTag(CardTags.STARTER_DEFEND) && c.type != CardType.STATUS && c.rarity != CardRarity.SPECIAL && c.color != AbstractDungeon.player.getCardColor();
-            if (this.upgraded) {
-                if (!c.canUpgrade()) validCard = false;
-                if (validCard) q.upgrade();
-            }
-            if (funkyPredicate.test(q)) {
-                if (validCard) tmp.add(c.cardID);
-            }
-        }
-
-        AbstractCard cUnknown;
-        if (tmp.size() > 0) {
-            cUnknown = CardLibrary.cards.get(tmp.get(AbstractDungeon.cardRng.random(0, tmp.size() - 1))).makeStatEquivalentCopy();
-        } else {
-            cUnknown = new com.megacrit.cardcrawl.cards.colorless.Madness();
-        }
-
-        if (this.upgraded) cUnknown.upgrade();
-        if (cUnknown != null) {
-            p.limbo.removeCard(this);
-            p.hand.removeCard(this);
-            p.drawPile.removeCard(this);
-            if (cUnknown.cardsToPreview == null)
-                cUnknown.cardsToPreview = this.makeStatEquivalentCopy();
-            AbstractDungeon.player.hand.addToTop(cUnknown);
-        }
+    @Override
+    public TextureAtlas.AtlasRegion getOverBannerTex() {
+        //TODO - Overbanner art
+        return SneckoMod.overBanner1;
     }
 }

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Fish_CaptainsOrders.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Fish_CaptainsOrders.java
@@ -12,7 +12,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.powers.*;
@@ -28,7 +27,7 @@ public class SS_Fish_CaptainsOrders extends AbstractExpansionCard
     
     public SS_Fish_CaptainsOrders() {
         super(ID, "replay/ss_fish_orders", COST, AbstractCard.CardType.POWER, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.SELF);
-        this.tags.add(downfallen.STUDY_PONDFISH);
+        //this.tags.add(downfallen.STUDY_PONDFISH);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 1;
         this.block = this.baseBlock = 10;

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Fish_DragToHell.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Fish_DragToHell.java
@@ -10,7 +10,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.core.*;
@@ -25,10 +24,12 @@ public class SS_Fish_DragToHell extends AbstractExpansionCard
     
     public SS_Fish_DragToHell() {
         super(ID, "replay/ss_fish_drown", COST, AbstractCard.CardType.SKILL, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.ENEMY);
-        this.tags.add(downfallen.STUDY_PONDFISH);
+       //this.tags.add(downfallen.STUDY_PONDFISH);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 6;
         this.exhaust = true;
+        this.setBackgroundTexture("expansioncontentResources/images/512/bg_boss_skill.png", "expansioncontentResources/images/1024/bg_boss_skill.png");
+
     }
     
     public void use(final AbstractPlayer p, final AbstractMonster m) {

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Fish_LivingLantern.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Fish_LivingLantern.java
@@ -10,7 +10,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.powers.*;
@@ -26,7 +25,7 @@ public class SS_Fish_LivingLantern extends AbstractExpansionCard
     
     public SS_Fish_LivingLantern() {
         super(ID, "replay/ss_fish_light", COST, AbstractCard.CardType.SKILL, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.SELF);
-        this.tags.add(downfallen.STUDY_PONDFISH);
+        //this.tags.add(downfallen.STUDY_PONDFISH);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 8;
         //ExhaustiveVariable.setBaseValue(this, 2);

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Fish_SixFeetUnder.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Fish_SixFeetUnder.java
@@ -10,7 +10,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.*;
 import com.megacrit.cardcrawl.actions.common.*;
@@ -27,7 +26,7 @@ public class SS_Fish_SixFeetUnder extends AbstractExpansionCard
     
     public SS_Fish_SixFeetUnder() {
         super(ID, "replay/ss_fish_attack", COST, AbstractCard.CardType.ATTACK, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.ENEMY);
-        this.tags.add(downfallen.STUDY_PONDFISH);
+       // this.tags.add(downfallen.STUDY_PONDFISH);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 6;
         this.damage = this.baseDamage = 3;

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Forest_Fishers.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Forest_Fishers.java
@@ -11,7 +11,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.powers.*;
@@ -28,7 +27,7 @@ public class SS_Forest_Fishers extends AbstractExpansionCard
     
     public SS_Forest_Fishers() {
         super(ID, "replay/ss_forest_fish", COST, AbstractCard.CardType.POWER, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.SELF);
-        this.tags.add(downfallen.STUDY_FOREST);
+       // this.tags.add(downfallen.STUDY_FOREST);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 4;
     }

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Forest_LostForever.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Forest_LostForever.java
@@ -11,7 +11,6 @@ import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.patches.CardFieldStuff;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.core.*;
@@ -26,7 +25,7 @@ public class SS_Forest_LostForever extends AbstractExpansionCard
     
     public SS_Forest_LostForever() {
         super(ID, "replay/ss_forest_skill", COST, AbstractCard.CardType.SKILL, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.ENEMY);
-        this.tags.add(downfallen.STUDY_FOREST);
+       // this.tags.add(downfallen.STUDY_FOREST);
         this.tags.add(expansionContentMod.STUDY);
         this.tags.add(CardFieldStuff.CHAOS_NEGATIVE_MAGIC);
         this.magicNumber = this.baseMagicNumber = 15;

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Forest_ManyPaths.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Forest_ManyPaths.java
@@ -10,7 +10,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.evacipated.cardcrawl.mod.stslib.actions.common.FetchAction;
 import com.evacipated.cardcrawl.mod.stslib.variables.ExhaustiveVariable;
@@ -27,7 +26,7 @@ public class SS_Forest_ManyPaths extends AbstractExpansionCard
     
     public SS_Forest_ManyPaths() {
         super(ID, "replay/ss_forest_skill", COST, AbstractCard.CardType.SKILL, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.SELF);
-        this.tags.add(downfallen.STUDY_FOREST);
+      //  this.tags.add(downfallen.STUDY_FOREST);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 1;
         ExhaustiveVariable.setBaseValue(this, 3);

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Forest_Treasure.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Forest_Treasure.java
@@ -21,7 +21,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.core.*;
@@ -36,10 +35,12 @@ public class SS_Forest_Treasure extends AbstractExpansionCard
     
     public SS_Forest_Treasure() {
         super(ID, "replay/ss_forest_treasure", COST, AbstractCard.CardType.POWER, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.SELF);
-        this.tags.add(downfallen.STUDY_FOREST);
+       // this.tags.add(downfallen.STUDY_FOREST);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 2;
-    }
+		this.setBackgroundTexture("expansioncontentResources/images/512/bg_boss_power.png", "expansioncontentResources/images/1024/bg_boss_power.png");
+
+	}
     
     public void use(final AbstractPlayer p, final AbstractMonster m) {
     	for (int i=0; i<this.magicNumber; i++) {

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Hec_Dynamite.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Hec_Dynamite.java
@@ -11,7 +11,6 @@ import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.patches.CardFieldStuff;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.core.*;
@@ -26,7 +25,7 @@ public class SS_Hec_Dynamite extends AbstractExpansionCard
     
     public SS_Hec_Dynamite() {
         super(ID, "replay/ss_hec_dynamite", COST, AbstractCard.CardType.ATTACK, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.ALL_ENEMY);
-        this.tags.add(downfallen.STUDY_HEC);
+      //  this.tags.add(downfallen.STUDY_HEC);
         this.tags.add(expansionContentMod.STUDY);
         this.tags.add(CardFieldStuff.CHAOS_NEGATIVE_MAGIC);
         this.isMultiDamage = true;

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Hec_ForgedInHellfire.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Hec_ForgedInHellfire.java
@@ -10,7 +10,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.powers.*;
@@ -26,11 +25,13 @@ public class SS_Hec_ForgedInHellfire extends AbstractExpansionCard
     
     public SS_Hec_ForgedInHellfire() {
         super(ID, "replay/ss_hec_hellfire", COST, AbstractCard.CardType.POWER, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.SELF);
-        this.tags.add(downfallen.STUDY_HEC);
+     //   this.tags.add(downfallen.STUDY_HEC);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 3;
+        this.setBackgroundTexture("expansioncontentResources/images/512/bg_boss_power.png", "expansioncontentResources/images/1024/bg_boss_power.png");
+
     }
-    
+
     public void use(final AbstractPlayer p, final AbstractMonster m) {
     	AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(p, p, new ArtifactPower(p, this.magicNumber-1), this.magicNumber-1));
     	AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(p, p, new ForgedInHellfireAltPower(p, this.magicNumber), this.magicNumber));

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Hec_SteelHeart.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/cards/replayxover/spireboss/SS_Hec_SteelHeart.java
@@ -10,7 +10,6 @@ import com.megacrit.cardcrawl.dungeons.*;
 import expansioncontent.expansionContentMod;
 import expansioncontent.cards.AbstractExpansionCard;
 import replayTheSpire.replayxover.downfallbs;
-import replayTheSpire.replayxover.downfallen;
 
 import com.megacrit.cardcrawl.actions.common.*;
 import com.megacrit.cardcrawl.powers.*;
@@ -27,7 +26,7 @@ public class SS_Hec_SteelHeart extends AbstractExpansionCard
     
     public SS_Hec_SteelHeart() {
         super(ID, "replay/ss_hec_heart", COST, AbstractCard.CardType.POWER, AbstractCard.CardRarity.UNCOMMON, AbstractCard.CardTarget.SELF);
-        this.tags.add(downfallen.STUDY_HEC);
+       // this.tags.add(downfallen.STUDY_HEC);
         this.tags.add(expansionContentMod.STUDY);
         this.magicNumber = this.baseMagicNumber = 10;
         this.block = this.baseBlock = 5;

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/powers/replayxover/StudyFableSpinnerPower.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/powers/replayxover/StudyFableSpinnerPower.java
@@ -1,3 +1,4 @@
+/*
 package com.megacrit.cardcrawl.mod.replay.powers.replayxover;
 
 import com.megacrit.cardcrawl.powers.*;
@@ -50,3 +51,4 @@ public class StudyFableSpinnerPower extends AbstractPower
         }
     }
 }
+*/

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/powers/replayxover/StudyHecPower.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/powers/replayxover/StudyHecPower.java
@@ -1,3 +1,4 @@
+/*
 package com.megacrit.cardcrawl.mod.replay.powers.replayxover;
 
 import com.megacrit.cardcrawl.powers.*;
@@ -51,3 +52,5 @@ public class StudyHecPower extends AbstractPower
         }
     }
 }
+
+*/

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/powers/replayxover/StudyPondfishPower.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/powers/replayxover/StudyPondfishPower.java
@@ -1,3 +1,4 @@
+/*
 package com.megacrit.cardcrawl.mod.replay.powers.replayxover;
 
 import com.megacrit.cardcrawl.powers.*;
@@ -51,3 +52,5 @@ public class StudyPondfishPower extends AbstractPower
         }
     }
 }
+
+*/

--- a/src/main/java/com/megacrit/cardcrawl/mod/replay/relics/M_GuardianBlood.java
+++ b/src/main/java/com/megacrit/cardcrawl/mod/replay/relics/M_GuardianBlood.java
@@ -6,6 +6,7 @@ import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.AbstractCard.CardColor;
 import com.megacrit.cardcrawl.cards.red.*;
+import com.megacrit.cardcrawl.cards.red.BodySlam;
 import com.megacrit.cardcrawl.characters.AbstractPlayer.PlayerClass;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.mod.replay.cards.red.*;

--- a/src/main/java/replayTheSpire/replayxover/downfallbs.java
+++ b/src/main/java/replayTheSpire/replayxover/downfallbs.java
@@ -28,16 +28,30 @@ import slimebound.powers.SlimedPower;
 
 public class downfallbs {
 	public static void addBossCards() {
+
+		/**
+		Bosses each only have one card now, to avoid thickening the pool too much.  Feel free to add this back in as desired.
+		Boss cards need to have a template override assigned, which each of the three uncommented ones do.
+		**/
+
 		BaseMod.addCard(new SS_Fish_DragToHell());
-		BaseMod.addCard(new SS_Fish_LivingLantern());
-		BaseMod.addCard(new SS_Fish_SixFeetUnder());
+		//BaseMod.addCard(new SS_Fish_LivingLantern());
+		//BaseMod.addCard(new SS_Fish_SixFeetUnder());
 		BaseMod.addCard(new SS_Forest_Treasure());
-		BaseMod.addCard(new SS_Forest_LostForever());
-		BaseMod.addCard(new SS_Forest_Fishers());
+		//BaseMod.addCard(new SS_Forest_LostForever());
+		//BaseMod.addCard(new SS_Forest_Fishers());
 		BaseMod.addCard(new SS_Hec_ForgedInHellfire());
-		BaseMod.addCard(new SS_Hec_SteelHeart());
-		BaseMod.addCard(new SS_Hec_Dynamite());
-		BaseMod.addCard(new UnknownCurse());
+		//BaseMod.addCard(new SS_Hec_SteelHeart());
+		//BaseMod.addCard(new SS_Hec_Dynamite());
+
+
+		/**
+		 Unknowns are VERY different now and would probably tough to make a new one.  I didn't see this hooked up to anything,
+		 so I didn't worry about it right now.  But we'll probably need to do some support on our end to allow modded Unknowns.
+		 Unknown Curse is set up to be basically what Unknowns are now, but there's a lot of hooks elsewhere.
+		 **/
+
+		//BaseMod.addCard(new UnknownCurse());
 	}
 	/*
 	public static boolean inEvilMode() {
@@ -47,9 +61,13 @@ public class downfallbs {
 			return false;
 		}
 	}*/
-	
-	
-	
+
+
+
+	/**
+	 Quick Study and the like are now fully tag-driven, so no patches are needed any more.
+	 **/
+
 	/*@SpirePatch(cls = "expansioncontent.cards.StudyTheSpire", method = "use", optional = true)
 	public static class StudyTheSpirePatch
 	{
@@ -60,6 +78,7 @@ public class downfallbs {
 	        powers.add(new StudyHecPower(p, p, __instance.magicNumber, __instance.upgraded));
 	    }
 	}*/
+	/*
     @SpirePatch(cls = "slimebound.powers.SlimedPower", method = "onAttacked", optional = true)
 	public static class SlimedRelicPatch
 	{
@@ -72,6 +91,8 @@ public class downfallbs {
 	    	}
 	    }
 	}
+
+
     @SpirePatch(cls = "expansioncontent.cards.QuickStudy", method = "choiceList", optional = true)
 	public static class QuickStudyPatch
 	{
@@ -125,7 +146,9 @@ public class downfallbs {
 	        return SpireReturn.Continue();
 	    }
 	}
-    
+	*/
+
+
     @SpirePatch(cls = "sneckomod.cards.AbstractSneckoCard", method = "getCorrectPlaceholderImage", optional = true)
 	public static class SnekboiPatch
 	{

--- a/src/main/java/replayTheSpire/replayxover/downfallen.java
+++ b/src/main/java/replayTheSpire/replayxover/downfallen.java
@@ -1,3 +1,10 @@
+
+/**
+ The individual type study tags aren't used any ore.  These are no longer needed.
+ The 'typed' Study powers are also no longer needed.  Their files are now commented out.
+ **/
+
+/*
 package replayTheSpire.replayxover;
 
 import com.evacipated.cardcrawl.modthespire.lib.SpireEnum;
@@ -11,3 +18,5 @@ public class downfallen {
     @SpireEnum
     public static AbstractCard.CardTags STUDY_HEC;
 }
+
+*/


### PR DESCRIPTION
All changes commented.

Boss Cards given the new red frames, reduced boss card count to 1 per boss.  Removed all previous patches for quick study/study the spire type effects as these are now dynamic with just the STUDY tag.  Quick Study in particular was problematic as it is no longer an OctoChoice card, but uses new tech.

Commented out Unknown Curse card for the moment, but did convert it to the new system.  We may have to add supporting hooks for modded Unknown cards if Unknown Curse is intended to be used.

Fixed an incompatibility in red cards list, not having Ironclad as an import, so it was pulling Guardian's Body Slam.